### PR TITLE
左旋関連のレジスタ処理が正しく動作するよう修正

### DIFF
--- a/cxd2857er.c
+++ b/cxd2857er.c
@@ -738,6 +738,9 @@ static int cxd2857_tune(struct cxd2878_dev *dev, u32 frequencykHz)
 		break;
 
 	case SONY_DTV_SYSTEM_ISDBS:
+		tvSystem = SONY_FREIA_STV_ISDBS;
+		tuner_state = SONY_TUNER_STATE_S;
+		break;
 	case SONY_DTV_SYSTEM_ISDBS3:
 		tvSystem = SONY_FREIA_STV_ISDBS3;
 		tuner_state = SONY_TUNER_STATE_S;

--- a/cxd2857er.c
+++ b/cxd2857er.c
@@ -739,6 +739,7 @@ static int cxd2857_tune(struct cxd2878_dev *dev, u32 frequencykHz)
 
 	case SONY_DTV_SYSTEM_ISDBS:
 	case SONY_DTV_SYSTEM_ISDBS3:
+		tvSystem = SONY_FREIA_STV_ISDBS3;
 		tuner_state = SONY_TUNER_STATE_S;
 		break;
 	default:


### PR DESCRIPTION
# 概要
BS左旋を選局した場合にcxd2857_tuneのif (2150000 < frequencykHz && tvSystem == SONY_FREIA_STV_ISDBS3)以下の処理を実行する必要がありますが、現在の実装ではtvSystem == SONY_FREIA_STV_ISDBS3の部分で弾かれこの処理が実行されません。
そのため、当コミットにより該当の処理が実行されるように変更しました。